### PR TITLE
Foreground incoming message handling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ This is the comparison table of functions implemented within this plugin accordi
 | [clearDeviceInterests](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/clearDeviceInterests.html) | ✅   | ✅       | ✅   |
 | [getDeviceInterests](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/getDeviceInterests.html)   | ✅   | ✅       | ✅   |
 | [onInterestChanges](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/onInterestChanges.html)    | ✅   | ✅       | ⬜️   |
+| [onMessageReceivedInTheForeground](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/onMessageReceivedInTheForeground.html)    | ✅   | ✅       | ⬜️   |
 | [removeDeviceInterest](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/removeDeviceInterest.html) | ✅   | ✅       | ✅   |
 | [setDeviceInterests](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/setDeviceInterests.html)   | ✅   | ✅       | ✅   |
 | [setUserId](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/setUserId.html)            | ✅   | ✅       | ✅   |
 | [start](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/start.html)                | ✅   | ✅       | ✅   |
 | [stop](https://pub.dev/documentation/pusher_beams/latest/pusher_beams/PusherBeams/stop.html)                 | ✅   | ✅       | ✅   |
+
 
 ## Platform Support
 

--- a/packages/pusher_beams/example/lib/main.dart
+++ b/packages/pusher_beams/example/lib/main.dart
@@ -52,7 +52,26 @@ class _MyAppState extends State<MyApp> {
     if (!kIsWeb) {
       await PusherBeams.instance
           .onInterestChanges((interests) => {print('Interests: $interests')});
+
+      await PusherBeams.instance
+          .onMessageReceivedInTheForeground(_onMessageReceivedInTheForeground);
     }
+  }
+
+  void _onMessageReceivedInTheForeground(Map<Object?, Object?> data) {
+    _showAlert(data["title"].toString(), data["body"].toString());
+  }
+
+  void _showAlert(String title, String message) {
+    AlertDialog alert = AlertDialog(
+        title: Text(title), content: Text(message), actions: const []);
+
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return alert;
+      },
+    );
   }
 
   @override

--- a/packages/pusher_beams/example/lib/main.dart
+++ b/packages/pusher_beams/example/lib/main.dart
@@ -6,8 +6,8 @@ import 'package:pusher_beams/pusher_beams.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await PusherBeams.instance.start(
-      '4232d328-8223-4c2a-bda3-36e4927321ce'); // Supply your own instanceId
+  await PusherBeams.instance
+      .start('your-instance-id'); // Supply your own instanceId
 
   runApp(const MyApp());
 }

--- a/packages/pusher_beams/example/lib/main.dart
+++ b/packages/pusher_beams/example/lib/main.dart
@@ -6,20 +6,34 @@ import 'package:pusher_beams/pusher_beams.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await PusherBeams.instance
-      .start('your-instance-id'); // Supply your own instanceId
+  await PusherBeams.instance.start(
+      '4232d328-8223-4c2a-bda3-36e4927321ce'); // Supply your own instanceId
 
   runApp(const MyApp());
 }
 
-class MyApp extends StatefulWidget {
+class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
 
   @override
-  State<MyApp> createState() => _MyAppState();
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Pusher Beams Flutter Example',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const MyHomePage(title: 'Pusher Beams Flutter Example'),
+    );
+  }
 }
 
-class _MyAppState extends State<MyApp> {
+class MyHomePage extends StatefulWidget {
+  const MyHomePage({Key? key, required this.title}) : super(key: key);
+  final String title;
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
   @override
   initState() {
     super.initState();
@@ -35,7 +49,7 @@ class _MyAppState extends State<MyApp> {
       ..credentials = 'omit';
 
     await PusherBeams.instance.setUserId(
-        'THIS IS AN USER ID',
+        'user-id',
         provider,
         (error) => {
               if (error != null) {print(error)}
@@ -90,6 +104,11 @@ class _MyAppState extends State<MyApp> {
                   await PusherBeams.instance.addDeviceInterest('bananas');
                 },
                 child: const Text('I like bananas')),
+            OutlinedButton(
+                onPressed: () async {
+                  await PusherBeams.instance.removeDeviceInterest('bananas');
+                },
+                child: const Text("I don't like banana anymore")),
             OutlinedButton(
                 onPressed: () async {
                   await PusherBeams.instance.addDeviceInterest('apples');

--- a/packages/pusher_beams/example/pubspec.lock
+++ b/packages/pusher_beams/example/pubspec.lock
@@ -177,34 +177,34 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   pusher_beams_android:
     dependency: transitive
     description:
-      name: pusher_beams_android
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../pusher_beams_android"
+      relative: true
+    source: path
     version: "1.0.1"
   pusher_beams_ios:
     dependency: transitive
     description:
-      name: pusher_beams_ios
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1"
+      path: "../../pusher_beams_ios"
+      relative: true
+    source: path
+    version: "1.0.2"
   pusher_beams_platform_interface:
     dependency: transitive
     description:
-      name: pusher_beams_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../pusher_beams_platform_interface"
+      relative: true
+    source: path
     version: "1.0.3"
   pusher_beams_web:
     dependency: transitive
     description:
-      name: pusher_beams_web
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../pusher_beams_web"
+      relative: true
+    source: path
     version: "1.0.1"
   sky_engine:
     dependency: transitive

--- a/packages/pusher_beams/lib/pusher_beams.dart
+++ b/packages/pusher_beams/lib/pusher_beams.dart
@@ -247,6 +247,26 @@ class PusherBeams extends PusherBeamsPlatform with CallbackHandlerApi {
     }
   }
 
+  /// Registers a listener which calls back the [OnMessageReceivedInTheForeground] function when the app receives a push notification in the background.
+  /// **This is not implemented on web.**
+  ///
+  /// Notification is a map containing the following keys:
+  ///   * title
+  ///   * body
+  ///   * data
+  ///
+  /// ## Example Usage
+  ///
+  /// ```dart
+  /// function someAsyncFunction() async {
+  ///   await PusherBeams.instance.onMessageReceivedInTheForeground((notification) => {
+  ///     print('Message received in the foreground: $notification')
+  ///   });
+  /// }
+  /// ```
+  ///
+  /// Throws an [Exception] in case of failure.
+
   @override
   Future<void> onMessageReceivedInTheForeground(
       OnMessageReceivedInTheForeground callback) async {

--- a/packages/pusher_beams/lib/pusher_beams.dart
+++ b/packages/pusher_beams/lib/pusher_beams.dart
@@ -247,7 +247,7 @@ class PusherBeams extends PusherBeamsPlatform with CallbackHandlerApi {
     }
   }
 
-  /// Registers a listener which calls back the [OnMessageReceivedInTheForeground] function when the app receives a push notification in the background.
+  /// Registers a listener which calls back the [OnMessageReceivedInTheForeground] function when the app receives a push notification in the foreground.
   /// **This is not implemented on web.**
   ///
   /// Notification is a map containing the following keys:

--- a/packages/pusher_beams/lib/pusher_beams.dart
+++ b/packages/pusher_beams/lib/pusher_beams.dart
@@ -247,6 +247,19 @@ class PusherBeams extends PusherBeamsPlatform with CallbackHandlerApi {
     }
   }
 
+  @override
+  Future<void> onMessageReceivedInTheForeground(
+      OnMessageReceivedInTheForeground callback) async {
+    final callbackId = _uuid.v4();
+
+    if (!kIsWeb) {
+      _callbacks[callbackId] = callback;
+    }
+
+    await _pusherBeamsApi
+        .onMessageReceivedInTheForeground(kIsWeb ? callback : callbackId);
+  }
+
   /// Handler which receives callbacks from the native platforms.
   /// This currently supports [onInterestChanges] and [setUserId] callbacks
   /// but by default it just call the [Function] set.
@@ -262,6 +275,9 @@ class PusherBeams extends PusherBeamsPlatform with CallbackHandlerApi {
         return;
       case "setUserId":
         callback(args[0] as String?);
+        return;
+      case "onMessageReceivedInTheForeground":
+        callback(args[0] as Map<String?, String?>?);
         return;
       default:
         callback();

--- a/packages/pusher_beams/lib/pusher_beams.dart
+++ b/packages/pusher_beams/lib/pusher_beams.dart
@@ -277,7 +277,7 @@ class PusherBeams extends PusherBeamsPlatform with CallbackHandlerApi {
         callback(args[0] as String?);
         return;
       case "onMessageReceivedInTheForeground":
-        callback(args[0] as Map<String?, String?>?);
+        callback((args[0] as Map<Object?, Object?>));
         return;
       default:
         callback();

--- a/packages/pusher_beams/pubspec.lock
+++ b/packages/pusher_beams/pubspec.lock
@@ -243,30 +243,30 @@ packages:
   pusher_beams_android:
     dependency: "direct main"
     description:
-      name: pusher_beams_android
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../pusher_beams_android"
+      relative: true
+    source: path
     version: "1.0.1"
   pusher_beams_ios:
     dependency: "direct main"
     description:
-      name: pusher_beams_ios
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1"
+      path: "../pusher_beams_ios"
+      relative: true
+    source: path
+    version: "1.0.2"
   pusher_beams_platform_interface:
     dependency: "direct main"
     description:
-      name: pusher_beams_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../pusher_beams_platform_interface"
+      relative: true
+    source: path
     version: "1.0.3"
   pusher_beams_web:
     dependency: "direct main"
     description:
-      name: pusher_beams_web
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../pusher_beams_web"
+      relative: true
+    source: path
     version: "1.0.1"
   sky_engine:
     dependency: transitive

--- a/packages/pusher_beams/pubspec.yaml
+++ b/packages/pusher_beams/pubspec.yaml
@@ -3,6 +3,7 @@ description: Official Flutter Plugin for Pusher Beams, receive notifications eas
 version: 1.0.1
 repository: https://github.com/pusher/flutter_pusher_beams
 issue_tracker: https://github.com/pusher/flutter_pusher_beams/issues
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -11,10 +12,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  pusher_beams_platform_interface: ^1.0.3
-  pusher_beams_web: ^1.0.1
-  pusher_beams_android: ^1.0.1
-  pusher_beams_ios: ^1.0.1
+  pusher_beams_platform_interface:
+    path: ../pusher_beams_platform_interface
+  pusher_beams_web:
+    path: ../pusher_beams_web
+  pusher_beams_android:
+    path: ../pusher_beams_android
+  pusher_beams_ios:
+    path: ../pusher_beams_ios
   uuid: ^3.0.5
 
 dev_dependencies:

--- a/packages/pusher_beams_android/android/src/main/java/com/pusher/pusher_beams/Messages.java
+++ b/packages/pusher_beams_android/android/src/main/java/com/pusher/pusher_beams/Messages.java
@@ -95,6 +95,7 @@ public class Messages {
     void onInterestChanges(String callbackId);
     void setUserId(String userId, BeamsAuthProvider provider, String callbackId);
     void clearAllState();
+    void onMessageReceivedInTheForeground(String callbackId);
     void stop();
 
     /** The codec used by PusherBeamsApi. */
@@ -302,6 +303,30 @@ public class Messages {
             Map<String, Object> wrapped = new HashMap<>();
             try {
               api.clearAllState();
+              wrapped.put("result", null);
+            }
+            catch (Error | RuntimeException exception) {
+              wrapped.put("error", wrapError(exception));
+            }
+            reply.reply(wrapped);
+          });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(binaryMessenger, "dev.flutter.pigeon.PusherBeamsApi.onMessageReceivedInTheForeground", getCodec());
+        if (api != null) {
+          channel.setMessageHandler((message, reply) -> {
+            Map<String, Object> wrapped = new HashMap<>();
+            try {
+              ArrayList<Object> args = (ArrayList<Object>)message;
+              String callbackIdArg = (String)args.get(0);
+              if (callbackIdArg == null) {
+                throw new NullPointerException("callbackIdArg unexpectedly null.");
+              }
+              api.onMessageReceivedInTheForeground(callbackIdArg);
               wrapped.put("result", null);
             }
             catch (Error | RuntimeException exception) {

--- a/packages/pusher_beams_android/android/src/main/kotlin/com/pusher/pusher_beams/PusherBeamsPlugin.kt
+++ b/packages/pusher_beams_android/android/src/main/kotlin/com/pusher/pusher_beams/PusherBeamsPlugin.kt
@@ -150,7 +150,7 @@ class PusherBeamsPlugin : FlutterPlugin, Messages.PusherBeamsApi, ActivityAware 
 }
 
 fun RemoteMessage.toPusherMessage() = mapOf(
-        "title" to notification?.title,
-        "body" to notification?.body,
-        "data" to data
+    "title" to notification?.title,
+    "body" to notification?.body,
+    "data" to data
 )

--- a/packages/pusher_beams_android/android/src/main/kotlin/com/pusher/pusher_beams/PusherBeamsPlugin.kt
+++ b/packages/pusher_beams_android/android/src/main/kotlin/com/pusher/pusher_beams/PusherBeamsPlugin.kt
@@ -15,135 +15,142 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 
 /** PusherBeamsPlugin */
-class PusherBeamsPlugin: FlutterPlugin, Messages.PusherBeamsApi, ActivityAware {
-  private lateinit var context : Context
-  private var alreadyInterestsListener : Boolean = false
-  private var currentActivity: Activity? = null
+class PusherBeamsPlugin : FlutterPlugin, Messages.PusherBeamsApi, ActivityAware {
+    private lateinit var context: Context
+    private var alreadyInterestsListener: Boolean = false
+    private var currentActivity: Activity? = null
 
-  private lateinit var callbackHandlerApi: Messages.CallbackHandlerApi
+    private lateinit var callbackHandlerApi: Messages.CallbackHandlerApi
 
-  override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    Messages.PusherBeamsApi.setup(flutterPluginBinding.binaryMessenger, this)
+    override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        Messages.PusherBeamsApi.setup(flutterPluginBinding.binaryMessenger, this)
 
-    context = flutterPluginBinding.applicationContext
-    callbackHandlerApi = Messages.CallbackHandlerApi(flutterPluginBinding.binaryMessenger)
-  }
-
-  override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
-    Messages.PusherBeamsApi.setup(binding.binaryMessenger, null)
-    callbackHandlerApi = Messages.CallbackHandlerApi(binding.binaryMessenger)
-  }
-
-  override fun start(instanceId: String) {
-    PushNotifications.start(this.context, instanceId)
-    Log.d(this.toString(), "PusherBeams started with $instanceId instanceId")
-  }
-
-  override fun addDeviceInterest(interest: String) {
-    PushNotifications.addDeviceInterest(interest)
-    Log.d(this.toString(), "Added device to interest: $interest")
-  }
-
-  override fun removeDeviceInterest(interest: String) {
-    PushNotifications.removeDeviceInterest(interest)
-    Log.d(this.toString(), "Removed device to interest: $interest")
-  }
-
-  override fun getDeviceInterests(): kotlin.collections.List<String> {
-    return PushNotifications.getDeviceInterests().toList()
-  }
-
-  override fun setDeviceInterests(interests: kotlin.collections.List<String>) {
-    PushNotifications.setDeviceInterests(interests.toSet())
-    Log.d(this.toString(), "$interests added to device")
-  }
-
-  override fun clearDeviceInterests() {
-    PushNotifications.clearDeviceInterests()
-    Log.d(this.toString(), "Cleared device interests")
-  }
-
-  override fun onInterestChanges(callbackId: String) {
-    if (!alreadyInterestsListener) {
-      PushNotifications.setOnDeviceInterestsChangedListener(object: SubscriptionsChangedListener {
-        override fun onSubscriptionsChanged(interests: Set<String>) {
-          callbackHandlerApi.handleCallback(callbackId, "onInterestChanges", listOf(interests.toList()), Messages.CallbackHandlerApi.Reply {
-            Log.d(this.toString(), "interests changed $interests")
-          })
-        }
-      })
+        context = flutterPluginBinding.applicationContext
+        callbackHandlerApi = Messages.CallbackHandlerApi(flutterPluginBinding.binaryMessenger)
     }
-  }
 
-  override fun setUserId(
-    userId: String,
-    provider: Messages.BeamsAuthProvider,
-    callbackId: String
-  ) {
-    val tokenProvider = BeamsTokenProvider(
-      provider.authUrl,
-      object: AuthDataGetter {
-        override fun getAuthData(): AuthData {
-          return AuthData(
-            headers = provider.headers,
-            queryParams = provider.queryParams
-          )
-        }
-      }
-    )
-
-    PushNotifications.setUserId(
-      userId,
-      tokenProvider,
-      object : BeamsCallback<Void, PusherCallbackError> {
-        override fun onFailure(error: PusherCallbackError) {
-          callbackHandlerApi.handleCallback(callbackId, "setUserId", listOf(error.message), Messages.CallbackHandlerApi.Reply {
-            Log.d(this.toString(), "Failed to set Authentication to device")
-          })
-        }
-
-        override fun onSuccess(vararg values: Void) {
-          callbackHandlerApi.handleCallback(callbackId, "setUserId", listOf(null), Messages.CallbackHandlerApi.Reply {
-            Log.d(this.toString(), "Device authenticated with $userId")
-          })
-        }
-      }
-    )
-  }
-
-  override fun clearAllState() {
-    PushNotifications.clearAllState()
-  }
-
-  override fun onMessageReceivedInTheForeground(callbackId: String) {
-    currentActivity?.let { activity ->
-        PushNotifications.setOnMessageReceivedListenerForVisibleActivity(activity, object : PushNotificationReceivedListener {
-          override fun onMessageReceived(remoteMessage: RemoteMessage) {
-            activity.runOnUiThread {
-              callbackHandlerApi.handleCallback(callbackId, "onMessageReceivedInTheForeground", listOf(remoteMessage)) {
-                Log.d(this.toString(), "Message received: ${remoteMessage.notification?.title}")
-              }
-            }
-          }
-        })
+    override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+        Messages.PusherBeamsApi.setup(binding.binaryMessenger, null)
+        callbackHandlerApi = Messages.CallbackHandlerApi(binding.binaryMessenger)
     }
-  }
 
-  override fun stop() {
-    PushNotifications.stop()
-  }
+    override fun start(instanceId: String) {
+        PushNotifications.start(this.context, instanceId)
+        Log.d(this.toString(), "PusherBeams started with $instanceId instanceId")
+    }
 
-  override fun onAttachedToActivity(pluginBinding: ActivityPluginBinding) {
-    this.currentActivity = pluginBinding.activity;
-  }
+    override fun addDeviceInterest(interest: String) {
+        PushNotifications.addDeviceInterest(interest)
+        Log.d(this.toString(), "Added device to interest: $interest")
+    }
 
-  override fun onDetachedFromActivityForConfigChanges() {
-  }
+    override fun removeDeviceInterest(interest: String) {
+        PushNotifications.removeDeviceInterest(interest)
+        Log.d(this.toString(), "Removed device to interest: $interest")
+    }
 
-  override fun onReattachedToActivityForConfigChanges(p0: ActivityPluginBinding) {
-  }
+    override fun getDeviceInterests(): kotlin.collections.List<String> {
+        return PushNotifications.getDeviceInterests().toList()
+    }
 
-  override fun onDetachedFromActivity() {
-    this.currentActivity = null;
-  }
+    override fun setDeviceInterests(interests: kotlin.collections.List<String>) {
+        PushNotifications.setDeviceInterests(interests.toSet())
+        Log.d(this.toString(), "$interests added to device")
+    }
+
+    override fun clearDeviceInterests() {
+        PushNotifications.clearDeviceInterests()
+        Log.d(this.toString(), "Cleared device interests")
+    }
+
+    override fun onInterestChanges(callbackId: String) {
+        if (!alreadyInterestsListener) {
+            PushNotifications.setOnDeviceInterestsChangedListener(object : SubscriptionsChangedListener {
+                override fun onSubscriptionsChanged(interests: Set<String>) {
+                    callbackHandlerApi.handleCallback(callbackId, "onInterestChanges", listOf(interests.toList()), Messages.CallbackHandlerApi.Reply {
+                        Log.d(this.toString(), "interests changed $interests")
+                    })
+                }
+            })
+        }
+    }
+
+    override fun setUserId(
+            userId: String,
+            provider: Messages.BeamsAuthProvider,
+            callbackId: String
+    ) {
+        val tokenProvider = BeamsTokenProvider(
+                provider.authUrl,
+                object : AuthDataGetter {
+                    override fun getAuthData(): AuthData {
+                        return AuthData(
+                                headers = provider.headers,
+                                queryParams = provider.queryParams
+                        )
+                    }
+                }
+        )
+
+        PushNotifications.setUserId(
+                userId,
+                tokenProvider,
+                object : BeamsCallback<Void, PusherCallbackError> {
+                    override fun onFailure(error: PusherCallbackError) {
+                        callbackHandlerApi.handleCallback(callbackId, "setUserId", listOf(error.message), Messages.CallbackHandlerApi.Reply {
+                            Log.d(this.toString(), "Failed to set Authentication to device")
+                        })
+                    }
+
+                    override fun onSuccess(vararg values: Void) {
+                        callbackHandlerApi.handleCallback(callbackId, "setUserId", listOf(null), Messages.CallbackHandlerApi.Reply {
+                            Log.d(this.toString(), "Device authenticated with $userId")
+                        })
+                    }
+                }
+        )
+    }
+
+    override fun clearAllState() {
+        PushNotifications.clearAllState()
+    }
+
+    override fun onMessageReceivedInTheForeground(callbackId: String) {
+        currentActivity?.let { activity ->
+            PushNotifications.setOnMessageReceivedListenerForVisibleActivity(activity, object : PushNotificationReceivedListener {
+                override fun onMessageReceived(remoteMessage: RemoteMessage) {
+                    activity.runOnUiThread {
+                        val pusherMessage = remoteMessage.toPusherMessage()
+                        callbackHandlerApi.handleCallback(callbackId, "onMessageReceivedInTheForeground", listOf(pusherMessage)) {
+                            Log.d(this.toString(), "Message received: $pusherMessage")
+                        }
+                    }
+                }
+            })
+        }
+    }
+
+    override fun stop() {
+        PushNotifications.stop()
+    }
+
+    override fun onAttachedToActivity(pluginBinding: ActivityPluginBinding) {
+        this.currentActivity = pluginBinding.activity;
+    }
+
+    override fun onDetachedFromActivityForConfigChanges() {
+    }
+
+    override fun onReattachedToActivityForConfigChanges(pluginBinding: ActivityPluginBinding) {
+    }
+
+    override fun onDetachedFromActivity() {
+        this.currentActivity = null;
+    }
 }
+
+fun RemoteMessage.toPusherMessage() = mapOf(
+        "title" to notification?.title,
+        "body" to notification?.body,
+        "data" to data
+)

--- a/packages/pusher_beams_android/pubspec.lock
+++ b/packages/pusher_beams_android/pubspec.lock
@@ -105,9 +105,9 @@ packages:
   pusher_beams_platform_interface:
     dependency: "direct main"
     description:
-      name: pusher_beams_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../pusher_beams_platform_interface"
+      relative: true
+    source: path
     version: "1.0.3"
   sky_engine:
     dependency: transitive

--- a/packages/pusher_beams_android/pubspec.yaml
+++ b/packages/pusher_beams_android/pubspec.yaml
@@ -3,6 +3,7 @@ description: The Android implementation from Pusher Beams for Flutter, intended 
 version: 1.0.1
 repository: https://github.com/pusher/flutter_pusher_beams
 issue_tracker: https://github.com/pusher/flutter_pusher_beams/issues?q=is%3Aissue+is%3Aopen+label%3Aandroid
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -11,7 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  pusher_beams_platform_interface: ^1.0.3
+  pusher_beams_platform_interface:
+    path: ../pusher_beams_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/pusher_beams_ios/ios/Classes/messages.h
+++ b/packages/pusher_beams_ios/ios/Classes/messages.h
@@ -30,6 +30,7 @@ NSObject<FlutterMessageCodec> *PusherBeamsApiGetCodec(void);
 - (void)onInterestChangesCallbackId:(NSString *)callbackId error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)setUserIdUserId:(NSString *)userId provider:(BeamsAuthProvider *)provider callbackId:(NSString *)callbackId error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)clearAllStateWithError:(FlutterError *_Nullable *_Nonnull)error;
+- (void)onMessageReceivedInTheForegroundCallbackId:(NSString *)callbackId error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)stopWithError:(FlutterError *_Nullable *_Nonnull)error;
 @end
 

--- a/packages/pusher_beams_ios/ios/Classes/messages.m
+++ b/packages/pusher_beams_ios/ios/Classes/messages.m
@@ -286,6 +286,26 @@ void PusherBeamsApiSetup(id<FlutterBinaryMessenger> binaryMessenger, NSObject<Pu
   {
     FlutterBasicMessageChannel *channel =
       [FlutterBasicMessageChannel
+        messageChannelWithName:@"dev.flutter.pigeon.PusherBeamsApi.onMessageReceivedInTheForeground"
+        binaryMessenger:binaryMessenger
+        codec:PusherBeamsApiGetCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(onMessageReceivedInTheForegroundCallbackId:error:)], @"PusherBeamsApi api (%@) doesn't respond to @selector(onMessageReceivedInTheForegroundCallbackId:error:)", api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        NSArray *args = message;
+        NSString *arg_callbackId = args[0];
+        FlutterError *error;
+        [api onMessageReceivedInTheForegroundCallbackId:arg_callbackId error:&error];
+        callback(wrapResult(nil, error));
+      }];
+    }
+    else {
+      [channel setMessageHandler:nil];
+    }
+  }
+  {
+    FlutterBasicMessageChannel *channel =
+      [FlutterBasicMessageChannel
         messageChannelWithName:@"dev.flutter.pigeon.PusherBeamsApi.stop"
         binaryMessenger:binaryMessenger
         codec:PusherBeamsApiGetCodec()];

--- a/packages/pusher_beams_ios/pubspec.lock
+++ b/packages/pusher_beams_ios/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -108,7 +108,7 @@ packages:
       path: "../pusher_beams_platform_interface"
       relative: true
     source: path
-    version: "0.0.1"
+    version: "1.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -155,7 +155,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -169,7 +169,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.20.0"

--- a/packages/pusher_beams_ios/pubspec.yaml
+++ b/packages/pusher_beams_ios/pubspec.yaml
@@ -11,7 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  pusher_beams_platform_interface: ^1.0.3
+  pusher_beams_platform_interface:
+    path: ../pusher_beams_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/pusher_beams_platform_interface/lib/method_channel_pusher_beams.dart
+++ b/packages/pusher_beams_platform_interface/lib/method_channel_pusher_beams.dart
@@ -298,6 +298,32 @@ class PusherBeamsApi extends PusherBeamsPlatform {
     }
   }
 
+  Future<void> onMessageReceivedInTheForeground(dynamic arg_callbackId) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.PusherBeamsApi.onMessageReceivedInTheForeground',
+        codec,
+        binaryMessenger: _binaryMessenger);
+    final Map<Object?, Object?>? replyMap =
+        await channel.send(<Object>[arg_callbackId]) as Map<Object?, Object?>?;
+    if (replyMap == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+        details: null,
+      );
+    } else if (replyMap['error'] != null) {
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
+      throw PlatformException(
+        code: (error['code'] as String?)!,
+        message: error['message'] as String?,
+        details: error['details'],
+      );
+    } else {
+      return;
+    }
+  }
+
   Future<void> stop() async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.PusherBeamsApi.stop', codec,

--- a/packages/pusher_beams_platform_interface/lib/pusher_beams_platform_interface.dart
+++ b/packages/pusher_beams_platform_interface/lib/pusher_beams_platform_interface.dart
@@ -6,6 +6,7 @@ import 'package:pusher_beams_platform_interface/method_channel_pusher_beams.dart
 
 typedef OnUserCallback = Function(String? error);
 typedef OnInterestsChange = Function(List<String?> interests);
+typedef OnMessageReceivedInTheForeground = Function(Map<String?, String?> data);
 
 abstract class PusherBeamsPlatform extends PlatformInterface {
   PusherBeamsPlatform() : super(token: _token);
@@ -69,5 +70,11 @@ abstract class PusherBeamsPlatform extends PlatformInterface {
 
   Future<void> stop() {
     throw UnimplementedError('stop() has not been implemented.');
+  }
+
+  Future<void> onMessageReceivedInTheForeground(
+      OnMessageReceivedInTheForeground callback) {
+    throw UnimplementedError(
+        'onMessageReceivedInTheForeground() has not been implemented.');
   }
 }

--- a/packages/pusher_beams_platform_interface/lib/pusher_beams_platform_interface.dart
+++ b/packages/pusher_beams_platform_interface/lib/pusher_beams_platform_interface.dart
@@ -6,14 +6,14 @@ import 'package:pusher_beams_platform_interface/method_channel_pusher_beams.dart
 
 typedef OnUserCallback = Function(String? error);
 typedef OnInterestsChange = Function(List<String?> interests);
-typedef OnMessageReceivedInTheForeground = Function(Map<String?, String?> data);
+typedef OnMessageReceivedInTheForeground = Function(Map<Object?, Object?> data);
 
 abstract class PusherBeamsPlatform extends PlatformInterface {
   PusherBeamsPlatform() : super(token: _token);
 
   static final Object _token = Object();
 
-  // NOTE: Remember to change .onInterestChanges and .setUserId last argument to dynamic on MethodChannel
+  // NOTE: Remember to change .onInterestChanges, .setUserId and .onMessageReceivedInTheForeground last argument to dynamic on MethodChannel
   static PusherBeamsPlatform _instance = PusherBeamsApi();
 
   /// The default instance of [PusherBeamsPlatform] to use.

--- a/packages/pusher_beams_platform_interface/pigeons/messages.dart
+++ b/packages/pusher_beams_platform_interface/pigeons/messages.dart
@@ -27,6 +27,8 @@ abstract class PusherBeamsApi {
 
   void clearAllState();
 
+  void onMessageReceivedInTheForeground(String callbackId);
+
   void stop();
 }
 

--- a/packages/pusher_beams_web/lib/pusher_beams.dart
+++ b/packages/pusher_beams_web/lib/pusher_beams.dart
@@ -30,6 +30,7 @@ class PusherBeamsClient {
   external Future<void> setUserId(String userId, TokenProvider provider);
   external Future<void> clearAllState();
   external Future<void> stop();
+  external Future<void> onMessageReceivedInTheForeground(String callbackId);
 }
 
 @JS()

--- a/packages/pusher_beams_web/lib/pusher_beams_web.dart
+++ b/packages/pusher_beams_web/lib/pusher_beams_web.dart
@@ -100,8 +100,7 @@ class PusherBeams extends PusherBeamsPlatform {
     }
   }
 
-  /// Adds an [html.ScriptElement] to the main page with the Pusher Beams SDK for web.
-  /// Then it register this device to Pusher Beams service with the given [instanceId].
+  /// Register this device to Pusher Beams service with the given [instanceId].
   ///
   /// You must call this method as soon as possible in your application.
   ///

--- a/packages/pusher_beams_web/lib/pusher_beams_web.dart
+++ b/packages/pusher_beams_web/lib/pusher_beams_web.dart
@@ -60,7 +60,8 @@ class PusherBeams extends PusherBeamsPlatform {
   /// This is not implemented on web platform
   @override
   Future<void> onInterestChanges(OnInterestsChange callback) async {
-    throw UnimplementedError('onInterestChanges() is not implemented on web');
+    // Just ignore
+    return;
   }
 
   /// Removes an [interest] in this device.
@@ -129,5 +130,13 @@ class PusherBeams extends PusherBeamsPlatform {
   Future<void> stop() async {
     await promiseToFuture(_beamsClient!.stop());
     _beamsClient = null;
+  }
+
+  @override
+  Future<void> onMessageReceivedInTheForeground(
+      OnMessageReceivedInTheForeground callback) async {
+    // Currently, we're not supporting foreground incoming message handling due to
+    // platform limitations on communication between Web Service Workers and Flutter ecossystem
+    return;
   }
 }

--- a/packages/pusher_beams_web/pubspec.lock
+++ b/packages/pusher_beams_web/pubspec.lock
@@ -124,9 +124,9 @@ packages:
   pusher_beams_platform_interface:
     dependency: "direct main"
     description:
-      name: pusher_beams_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../pusher_beams_platform_interface"
+      relative: true
+    source: path
     version: "1.0.3"
   sky_engine:
     dependency: transitive

--- a/packages/pusher_beams_web/pubspec.yaml
+++ b/packages/pusher_beams_web/pubspec.yaml
@@ -13,7 +13,8 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  pusher_beams_platform_interface: ^1.0.3
+  pusher_beams_platform_interface: 
+    path: ../pusher_beams_platform_interface
   js: ^0.6.3
   uuid: ^3.0.5
 


### PR DESCRIPTION
In this PR, we start supporting a way to handle push notifications when it arrives on a user's device, and the app is in the foreground. This feature already exists on Android, iOS and Web, but it was missing on FlutterSDK.

## Usage
The client needs to implement a function that receives push notification content as a `Map`.
```dart
..
PusherBeams.instance.onMessageReceivedInTheForeground(_onMessageReceivedInTheForeground);
..
void _onMessageReceivedInTheForeground(Map<Object?, Object?> data) {
    // handling message
}
```
## Screenshot
Android / iOS working. ("Web" still missing). I've sent those messages using REST API just for testing.

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/139697/153021027-39416929-46e9-496a-a098-d6d4077bcc3a.gif)![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/139697/153022823-cd953790-b4d5-48e2-bedb-25a1864fb2ad.gif)

## Next steps
* [x] Make it work on Web platform